### PR TITLE
Windows: Use find_file to find secp256k1.dl

### DIFF
--- a/coinlib_flutter/windows/CMakeLists.txt
+++ b/coinlib_flutter/windows/CMakeLists.txt
@@ -13,14 +13,38 @@ project(${PROJECT_NAME} LANGUAGES CXX)
 # add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../src" "${CMAKE_CURRENT_BINARY_DIR}/shared")
 # TODO re-enable the above line if/when the CMake process is made Windows-compatible.  See also below.
 
-# List of absolute paths to libraries that should be bundled with the plugin.
-# This list could contain prebuilt libraries, or libraries created by an
-# external build triggered from this build file.
-set(coinlib_flutter_bundled_libraries
-  # Defined in ../src/CMakeLists.txt.
-  # This can be changed to accommodate different builds.
-  # $<TARGET_FILE:coinlib_flutter>
-  # TODO re-enable the above line if/when the CMake process is made Windows-compatible.  See also above.
-  ${CMAKE_BINARY_DIR}/../../secp256k1.dll
-  PARENT_SCOPE
+# Search for secp256k1.dll in multiple possible directories.
+#
+# This is only necessary because in testing we have found that most Windows hosts
+# have CMAKE_BINARY_DIR = app/build/windows/x64, but some use app/build/windows.
+# This should search through its multiple possible locations. 
+find_file(SECP256K1_DLL
+    NAMES secp256k1.dll
+    PATHS
+        "${CMAKE_BINARY_DIR}/../" # Check one level up.
+        "${CMAKE_BINARY_DIR}/../secp256k1.dll"
+        "${CMAKE_BINARY_DIR}/../../" # Check two levels up.
+        "${CMAKE_BINARY_DIR}/../../secp256k1.dll"
+        "${CMAKE_BINARY_DIR}/../../../" # Should only be used for the example app.
+        "${CMAKE_BINARY_DIR}/../../../secp256k1.dll"
+        "${CMAKE_SOURCE_DIR}/../build" # Also search in CMAKE_SOURCE_DIR.
+        "${CMAKE_SOURCE_DIR}/../../build" # Works for the example app.
+    NO_DEFAULT_PATH
 )
+
+# Check if SECP256K1_DLL was found
+if (SECP256K1_DLL)
+    # List of absolute paths to libraries that should be bundled with the plugin.
+    # This list could contain prebuilt libraries, or libraries created by an
+    # external build triggered from this build file.
+    set(coinlib_flutter_bundled_libraries
+        # Defined in ../src/CMakeLists.txt.
+        # This can be changed to accommodate different builds.
+        # $<TARGET_FILE:coinlib_flutter>
+        # TODO re-enable the above line if/when the CMake process is made Windows-compatible.  See also above.
+        ${SECP256K1_DLL}
+        PARENT_SCOPE
+    )
+else ()
+    message(FATAL_ERROR "Could not find secp256k1.dll.")
+endif ()


### PR DESCRIPTION
In testing we found that CMAKE_BINARY_DIR is usually app/build/windows/x64, but some Windows hosts use app/build/windows. This should support both.

See also https://github.com/peercoin/coinlib/pull/26.