### PR TITLE
fix(windows): enable secp256k1 recovery module in Windows builders

### DIFF
--- a/coinlib/bin/build_windows.dart
+++ b/coinlib/bin/build_windows.dart
@@ -37,6 +37,7 @@ void main() async {
     ".",
     "-B",
     "build",
+    "-DSECP256K1_ENABLE_MODULE_RECOVERY=ON",
     "--debug-output",
   ]);
 

--- a/coinlib/bin/build_windows_crosscompile.dart
+++ b/coinlib/bin/build_windows_crosscompile.dart
@@ -19,7 +19,7 @@ RUN git clone https://github.com/bitcoin-core/secp256k1 \
 WORKDIR /secp256k1/build
 
 # Build shared library for Windows.
-RUN cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake/x86_64-w64-mingw32.toolchain.cmake
+RUN cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake/x86_64-w64-mingw32.toolchain.cmake -DSECP256K1_ENABLE_MODULE_RECOVERY=ON
 RUN make
 
 # Build DLL and copy into output.

--- a/coinlib/bin/build_wsl.dart
+++ b/coinlib/bin/build_wsl.dart
@@ -34,6 +34,7 @@ void main() async {
   await execWithStdio("cmake", [
     "..",
     "-DCMAKE_TOOLCHAIN_FILE=../cmake/x86_64-w64-mingw32.toolchain.cmake",
+    "-DSECP256K1_ENABLE_MODULE_RECOVERY=ON",
   ]);
 
   // Build the project using "make".


### PR DESCRIPTION
The CMake build of libsecp256k1 defaults SECP256K1_ENABLE_MODULE_RECOVERY to OFF, unlike the autotools builds used by build_linux.dart, build_macos.dart, and build_wasm.dart which pass --enable-module-recovery. As a result, secp256k1.dll built by build_windows.dart (and the WSL and docker cross-compile variants) lacked secp256k1_ecdsa_sign_recoverable and the other recovery module exports, breaking recoverable ECDSA message signing (MessageSignature) on Windows with:

  Invalid argument(s): Failed to lookup symbol
  'secp256k1_ecdsa_sign_recoverable': The specified procedure could not
  be found. (error code: 127)

Pass -DSECP256K1_ENABLE_MODULE_RECOVERY=ON in all three Windows builders.